### PR TITLE
Fixed typo in CmdLine usage message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,8 @@ obj/
 [Dd]ebug*/
 [Rr]elease*/
 Ankh.NoLoad
+# VS now auto-creates Backup directories when migrating older solutions etc...
+Backup/
 
 #Tooling
 _ReSharper*/

--- a/PoorMansTSqlFormatterCmdLine/GeneralLanguageContent.resx
+++ b/PoorMansTSqlFormatterCmdLine/GeneralLanguageContent.resx
@@ -184,7 +184,7 @@ ae  allowParsingErrors (default: false)
 e   extensions (default: sql)
 r   recursive (default: false)
 b   backups (default: true)
-b   outputFileOrFolder (default: none; if set, overrides the backup option)
+o   outputFileOrFolder (default: none; if set, overrides the backup option)
 l   languageCode (default: current if supported or EN; valid values include EN, FR and ES)
 h ? help
 


### PR DESCRIPTION
"b" was incorrectly listed as the switch for outputFileOrFolder instead of "o"
Also, ignore new Visual Studio auto-created Backup/ directories.