### PR TITLE
appveyor update

### DIFF
--- a/PoorMansTSqlFormatter.sln
+++ b/PoorMansTSqlFormatter.sln
@@ -44,6 +44,9 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PoorMansTSqlFormatterSSMSAddIn.Setup.action", "PoorMansTSqlFormatterSSMSAddIn.Setup.action\PoorMansTSqlFormatterSSMSAddIn.Setup.action.csproj", "{604AEB5D-45FB-4959-B1B9-DC6D310A8F40}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PoorMansTSqlFormatterVSPackage", "PoorMansTSqlFormatterVSPackage\PoorMansTSqlFormatterVSPackage.csproj", "{B1175A57-8B7B-4B8D-ACE0-3597B6B729F8}"
+	ProjectSection(ProjectDependencies) = postProject
+		{679B3998-C5A5-4B64-8674-70BE959ACE6E} = {679B3998-C5A5-4B64-8674-70BE959ACE6E}
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/PoorMansTSqlFormatterTest/CmdLineTests.cs
+++ b/PoorMansTSqlFormatterTest/CmdLineTests.cs
@@ -28,8 +28,12 @@ namespace PoorMansTSqlFormatterTests
     [TestFixture]
     public class CmdLineTests
     {
-        private const string FORMATTER_EXECUTABLE = "..\\..\\..\\PoorMansTSqlFormatterCmdLine\\bin\\Debug\\SqlFormatter.exe";
-
+        #if DEBUG
+            private const string FORMATTER_EXECUTABLE = "..\\..\\..\\PoorMansTSqlFormatterCmdLine\\bin\\Debug\\SqlFormatter.exe";
+        #else
+            private const string FORMATTER_EXECUTABLE = "..\\..\\..\\PoorMansTSqlFormatterCmdLine\\bin\\Release\\SqlFormatter.exe";
+        #endif
+        
         [Test]
         public void TestCmdLineFormattingSwitches()
         {

--- a/PoorMansTSqlFormatterWebDemo/PoorMansTSqlFormatterWebDemo.csproj
+++ b/PoorMansTSqlFormatterWebDemo/PoorMansTSqlFormatterWebDemo.csproj
@@ -94,7 +94,7 @@
   </Target>
   -->
   <PropertyGroup>
-    <PostBuildEvent>Call $(ProjectDir)Postbuild_CopyJSLib.bat $(SolutionDir) $(ProjectDir)</PostBuildEvent>
+    <PostBuildEvent>Call $(ProjectDir)Postbuild_CopyJSLib.bat $(SolutionDir) $(ProjectDir) $(Configuration)</PostBuildEvent>
   </PropertyGroup>
   <ProjectExtensions>
     <VisualStudio>

--- a/PoorMansTSqlFormatterWebDemo/Postbuild_CopyJSLib.bat
+++ b/PoorMansTSqlFormatterWebDemo/Postbuild_CopyJSLib.bat
@@ -1,20 +1,20 @@
 REM Copy compiled JS libraries from another project
 
-copy %1PoorMansTSqlFormatterJSLib\bin\Debug\bridge\bridge.min.js %2JSLibReference\
+copy %1PoorMansTSqlFormatterJSLib\bin\%3\bridge\bridge.min.js %2JSLibReference\
 IF %ERRORLEVEL% NEQ 0 GOTO END
-copy %1PoorMansTSqlFormatterJSLib\bin\Debug\bridge\bridge.js %2JSLibReference\
+copy %1PoorMansTSqlFormatterJSLib\bin\%3\bridge\bridge.js %2JSLibReference\
 IF %ERRORLEVEL% NEQ 0 GOTO END
-copy %1PoorMansTSqlFormatterJSLib\bin\Debug\bridge\bridge.meta.min.js %2JSLibReference\
+copy %1PoorMansTSqlFormatterJSLib\bin\%3\bridge\bridge.meta.min.js %2JSLibReference\
 IF %ERRORLEVEL% NEQ 0 GOTO END
-copy %1PoorMansTSqlFormatterJSLib\bin\Debug\bridge\bridge.meta.js %2JSLibReference\
+copy %1PoorMansTSqlFormatterJSLib\bin\%3\bridge\bridge.meta.js %2JSLibReference\
 IF %ERRORLEVEL% NEQ 0 GOTO END
-copy %1PoorMansTSqlFormatterJSLib\bin\Debug\bridge\PoorMansTSqlFormatterJS.min.js %2JSLibReference\
+copy %1PoorMansTSqlFormatterJSLib\bin\%3\bridge\PoorMansTSqlFormatterJS.min.js %2JSLibReference\
 IF %ERRORLEVEL% NEQ 0 GOTO END
-copy %1PoorMansTSqlFormatterJSLib\bin\Debug\bridge\PoorMansTSqlFormatterJS.js %2JSLibReference\
+copy %1PoorMansTSqlFormatterJSLib\bin\%3\bridge\PoorMansTSqlFormatterJS.js %2JSLibReference\
 IF %ERRORLEVEL% NEQ 0 GOTO END
-copy %1PoorMansTSqlFormatterJSLib\bin\Debug\bridge\PoorMansTSqlFormatterJS.meta.min.js %2JSLibReference\
+copy %1PoorMansTSqlFormatterJSLib\bin\%3\bridge\PoorMansTSqlFormatterJS.meta.min.js %2JSLibReference\
 IF %ERRORLEVEL% NEQ 0 GOTO END
-copy %1PoorMansTSqlFormatterJSLib\bin\Debug\bridge\PoorMansTSqlFormatterJS.meta.js %2JSLibReference\
+copy %1PoorMansTSqlFormatterJSLib\bin\%3\bridge\PoorMansTSqlFormatterJS.meta.js %2JSLibReference\
 IF %ERRORLEVEL% NEQ 0 GOTO END
 
 :END

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,7 @@ environment:
 platform:
     - x64
     - x86
+    - PureDotNet
 
 configuration:
     - Release
@@ -37,7 +38,7 @@ after_build:
         }
 
         if ($env:PLATFORM -eq "x86" -and $env:CONFIGURATION -eq "Release") {
-            Push-AppveyorArtifact "PoorMansTSqlFormatterNppPlugin\bin\$env:CONFIGURATION\PoorMansTSqlFormatterNppPlugin.dll" -FileName PoorMansTSqlFormatterNppPlugin.dll
+            Push-AppveyorArtifact "PoorMansTSqlFormatterNppPlugin\bin\$env:PLATFORM\$env:CONFIGURATION\PoorMansTSqlFormatterNppPlugin.dll" -FileName PoorMansTSqlFormatterNppPlugin.dll
         }
 
         if ($($env:APPVEYOR_REPO_TAG) -eq "true" -and $env:CONFIGURATION -eq "Release" -and $env:PLATFORMTOOLSET -eq "v140_xp") {
@@ -47,7 +48,7 @@ after_build:
             }
             if($env:PLATFORM -eq "x86"){
             $ZipFileName = "PoorMansTSqlFormatterNppPlugin_$($env:APPVEYOR_REPO_TAG_NAME)_x86.zip"
-            7z a $ZipFileName PoorMansTSqlFormatterNppPlugin\bin\$env:CONFIGURATION\PoorMansTSqlFormatterNppPlugin.dll
+            7z a $ZipFileName PoorMansTSqlFormatterNppPlugin\bin\$env:PLATFORM\$env:CONFIGURATION\PoorMansTSqlFormatterNppPlugin.dll
             }
         }
 

--- a/packages/Bridge.Min.16.0.0-beta4/build/Bridge.Min.targets
+++ b/packages/Bridge.Min.16.0.0-beta4/build/Bridge.Min.targets
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <UsingTask TaskName="BridgeCompilerTask" AssemblyFile="$(MSBuildThisFileDirectory)..\tools\Bridge.Builder.v16.dll" />
+
+  <PropertyGroup>
+    <NoStdLib>True</NoStdLib>
+    <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
+    <AdditionalExplicitAssemblyReferences />
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PrepareForRunDependsOn>$(PrepareForRunDependsOn);BridgeNetGenerateScript</PrepareForRunDependsOn>
+  </PropertyGroup>
+
+  <Target Name="BridgeNetGenerateScript">
+    <Message Text="------ BridgeNetGenerateScript task started: Project: $(MSBuildProjectName), Configuration: $(Configuration) $(Platform) OutputPath: $(OutputPath) ------" Importance="high" />
+
+    <BridgeCompilerTask
+      Assembly="@(IntermediateAssembly)"
+      AssemblyName="$(AssemblyName)"
+      AssembliesPath="$(OutDir)"
+      CheckForOverflowUnderflow="$(CheckForOverflowUnderflow)"
+      Configuration="$(Configuration)"
+      DefineConstants="$(DefineConstants)"
+      OutDir="$(OutDir)"
+      OutputPath="$(OutputPath)"
+      OutputType="$(OutputType)"
+      Platform="$(Platform)"
+      ProjectPath="$(MSBuildProjectFullPath)"
+      RootNamespace="$(RootNamespace)"
+      Sources="@(Compile)" />
+
+    <Message Text="------ BridgeNetGenerateScript task done: Project: $(MSBuildProjectName), Configuration: $(Configuration) $(Platform) OutputPath: $(OutputPath) ------" Importance="high" />
+  </Target>
+</Project>


### PR DESCRIPTION
- corrected appveyor.yml for publishing x86 binary
- adapted Postbuild_CopyJSLib.bat script to also work for release builds
- added PureDotNet as further build target, see https://ci.appveyor.com/project/chcg/poormanstsqlformatter/build/1.6.12.21, for the nuget package Bridge.Min the build folder with Bridge.Min.targets is missing in the github repo, added 
- furthermore the test PoorMansTSqlFormatterTest\CmdLineTests.cs contains

        private const string FORMATTER_EXECUTABLE = "..\\..\\..\\PoorMansTSqlFormatterCmdLine\\bin\\Debug\\SqlFormatter.exe";

therefore 2 failing release tests, fixed by ifdef for the release path

- regarding the warnings:
 C:\Program Files (x86)\MSBuild\14.0\bin\Microsoft.Common.CurrentVersion.targets(1820,5): warning MSB3275: The primary reference "C:\projects\poormanstsqlformatter\PoorMansTSqlFormatterJSLib\bin\Debug\PoorMansTSqlFormatterJS.dll" could not be resolved because it has an indirect dependency on the assembly "Bridge, Version=16.0.0.0, Culture=neutral, PublicKeyToken=null" which was built against the ".NETFramework,Version=v4.0" framework. This is a higher version than the currently targeted framework ".NETFramework,Version=v2.0". [C:\projects\poormanstsqlformatter\PoorMansTSqlFormatterWebDemo\PoorMansTSqlFormatterWebDemo.csproj]

maybe check http://windows-installer-xml-wix-toolset.687559.n2.nabble.com/AllowDowngrades-quot-yes-quot-warning-LGHT1076-ICE61-td7585146.html or https://stackoverflow.com/questions/37941133/ice61-this-product-should-remove-only-older-versions-of-itself

- added build dependedncy for the multithreaded build with /m, because otherwise it leads to the error:

    15>DeployVsixExtensionFiles:
         C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\devenv.exe /RootSuffix Exp /ResetSettings General.vssettings /Embedding /Command File.Exit 
         log4net:ERROR [RollingFileAppender] Unable to acquire lock on file C:\Users\appveyor\AppData\Local\AWSToolkit\logs\visualstudio\log.txt. The process cannot access the file 'C:\Users\appveyor\AppData\Local\AWSToolkit\logs\visualstudio\log.txt' because it is being used by another process.
    12>C:\projects\poormanstsqlformatter\packages\Microsoft.VisualStudio.Sdk.BuildTasks.14.0.14.0.215\tools\VSSDK\Microsoft.VsSDK.targets(743,5): error VSSDK1040: There was a problem enabling the extension with a VSIX identifier of "247609b1-2692-47d6-972a-976544685f0e". Catastrophic failure (Exception from HRESULT: 0x8000FFFF (E_UNEXPECTED)) [C:\projects\poormanstsqlformatter\PoorMansTSqlFormatterSSMSPackage\PoorMansTSqlFormatterSSMSPackage.csproj]

, the build dependency removes this limitation
