### PR TITLE
Option to expand after select

### DIFF
--- a/PoorMansTSqlFormatterCmdLine/Program.cs
+++ b/PoorMansTSqlFormatterCmdLine/Program.cs
@@ -54,6 +54,7 @@ namespace PoorMansTSqlFormatterCmdLine
                     ExpandBetweenConditions = true,
                     ExpandBooleanExpressions = true,
                     ExpandCaseStatements = true,
+                    ExpandSelectStatements = true,
                     ExpandCommaLists = true,
                     BreakJoinOnSections = false,
                     UppercaseKeywords = true,
@@ -83,6 +84,7 @@ namespace PoorMansTSqlFormatterCmdLine
               .Add("ebc|expandBetweenConditions", delegate(string v) { options.ExpandBetweenConditions = v != null; })
               .Add("ebe|expandBooleanExpressions", delegate(string v) { options.ExpandBooleanExpressions = v != null; })
               .Add("ecs|expandCaseStatements", delegate(string v) { options.ExpandCaseStatements = v != null; })
+              .Add("ess|expandSelectStatements", delegate (string v) { options.ExpandSelectStatements = v != null; })
 			  .Add("ecl|expandCommaLists", delegate(string v) { options.ExpandCommaLists = v != null; })
 			  .Add("eil|expandInLists", delegate(string v) { options.ExpandInLists = v != null; })
 			  .Add("bjo|breakJoinOnSections", delegate(string v) { options.BreakJoinOnSections = v != null; })

--- a/PoorMansTSqlFormatterCmdLine/Program.cs
+++ b/PoorMansTSqlFormatterCmdLine/Program.cs
@@ -54,7 +54,7 @@ namespace PoorMansTSqlFormatterCmdLine
                     ExpandBetweenConditions = true,
                     ExpandBooleanExpressions = true,
                     ExpandCaseStatements = true,
-                    ExpandSelectStatements = true,
+                    ExpandSelectStatements = false,
                     ExpandCommaLists = true,
                     BreakJoinOnSections = false,
                     UppercaseKeywords = true,

--- a/PoorMansTSqlFormatterDemo/MainForm.Designer.cs
+++ b/PoorMansTSqlFormatterDemo/MainForm.Designer.cs
@@ -53,17 +53,22 @@ namespace PoorMansTSqlFormatterDemo
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.splitContainer4 = new System.Windows.Forms.SplitContainer();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.txt_Input = new PoorMansTSqlFormatterDemo.FrameworkClassReplacements.SelectableTextBox();
             this.splitContainer5 = new System.Windows.Forms.SplitContainer();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
+            this.txt_TokenizedSql = new PoorMansTSqlFormatterDemo.FrameworkClassReplacements.SelectableTextBox();
             this.groupBox3 = new System.Windows.Forms.GroupBox();
+            this.txt_ParsedXml = new PoorMansTSqlFormatterDemo.FrameworkClassReplacements.SelectableTextBox();
             this.splitContainer3 = new System.Windows.Forms.SplitContainer();
             this.groupBox4 = new System.Windows.Forms.GroupBox();
             this.panel1 = new System.Windows.Forms.Panel();
+            this.webBrowser_OutputSql = new PoorMansTSqlFormatterDemo.FrameworkClassReplacements.CustomContentWebBrowser();
             this.groupBox5 = new System.Windows.Forms.GroupBox();
             this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
             this.radio_Formatting_Identity = new System.Windows.Forms.RadioButton();
             this.radio_Formatting_Standard = new System.Windows.Forms.RadioButton();
             this.grp_Options = new System.Windows.Forms.GroupBox();
+            this.chk_ExpandSelectStatements = new System.Windows.Forms.CheckBox();
             this.chk_BreakJoinOnSections = new System.Windows.Forms.CheckBox();
             this.chk_ExpandInLists = new System.Windows.Forms.CheckBox();
             this.chk_EnableKeywordStandardization = new System.Windows.Forms.CheckBox();
@@ -101,14 +106,10 @@ namespace PoorMansTSqlFormatterDemo
             this.displayParsedSqlToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.displayFormattingOptionsAreaToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.languageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.txt_Input = new PoorMansTSqlFormatterDemo.FrameworkClassReplacements.SelectableTextBox();
-            this.txt_TokenizedSql = new PoorMansTSqlFormatterDemo.FrameworkClassReplacements.SelectableTextBox();
-            this.txt_ParsedXml = new PoorMansTSqlFormatterDemo.FrameworkClassReplacements.SelectableTextBox();
-            this.webBrowser_OutputSql = new PoorMansTSqlFormatterDemo.FrameworkClassReplacements.CustomContentWebBrowser();
             this.englishToolStripMenuItem = new PoorMansTSqlFormatterDemo.FrameworkClassReplacements.RadioToolStripMenuItem();
             this.frenchToolStripMenuItem = new PoorMansTSqlFormatterDemo.FrameworkClassReplacements.RadioToolStripMenuItem();
             this.spanishToolStripMenuItem = new PoorMansTSqlFormatterDemo.FrameworkClassReplacements.RadioToolStripMenuItem();
+            this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
             this.splitContainer1.SuspendLayout();
@@ -169,6 +170,14 @@ namespace PoorMansTSqlFormatterDemo
             this.groupBox1.Name = "groupBox1";
             this.groupBox1.TabStop = false;
             // 
+            // txt_Input
+            // 
+            this.txt_Input.AcceptsReturn = true;
+            this.txt_Input.AcceptsTab = true;
+            resources.ApplyResources(this.txt_Input, "txt_Input");
+            this.txt_Input.Name = "txt_Input";
+            this.txt_Input.TextChanged += new System.EventHandler(this.txt_Input_TextChanged);
+            // 
             // splitContainer5
             // 
             resources.ApplyResources(this.splitContainer5, "splitContainer5");
@@ -189,12 +198,28 @@ namespace PoorMansTSqlFormatterDemo
             this.groupBox2.Name = "groupBox2";
             this.groupBox2.TabStop = false;
             // 
+            // txt_TokenizedSql
+            // 
+            this.txt_TokenizedSql.AcceptsReturn = true;
+            this.txt_TokenizedSql.AcceptsTab = true;
+            resources.ApplyResources(this.txt_TokenizedSql, "txt_TokenizedSql");
+            this.txt_TokenizedSql.Name = "txt_TokenizedSql";
+            this.txt_TokenizedSql.ReadOnly = true;
+            // 
             // groupBox3
             // 
             this.groupBox3.Controls.Add(this.txt_ParsedXml);
             resources.ApplyResources(this.groupBox3, "groupBox3");
             this.groupBox3.Name = "groupBox3";
             this.groupBox3.TabStop = false;
+            // 
+            // txt_ParsedXml
+            // 
+            this.txt_ParsedXml.AcceptsReturn = true;
+            this.txt_ParsedXml.AcceptsTab = true;
+            resources.ApplyResources(this.txt_ParsedXml, "txt_ParsedXml");
+            this.txt_ParsedXml.Name = "txt_ParsedXml";
+            this.txt_ParsedXml.ReadOnly = true;
             // 
             // splitContainer3
             // 
@@ -224,10 +249,16 @@ namespace PoorMansTSqlFormatterDemo
             resources.ApplyResources(this.panel1, "panel1");
             this.panel1.Name = "panel1";
             // 
+            // webBrowser_OutputSql
+            // 
+            resources.ApplyResources(this.webBrowser_OutputSql, "webBrowser_OutputSql");
+            this.webBrowser_OutputSql.Name = "webBrowser_OutputSql";
+            this.webBrowser_OutputSql.ScriptErrorsSuppressed = true;
+            // 
             // groupBox5
             // 
-            this.groupBox5.Controls.Add(this.tableLayoutPanel2);
             resources.ApplyResources(this.groupBox5, "groupBox5");
+            this.groupBox5.Controls.Add(this.tableLayoutPanel2);
             this.groupBox5.Name = "groupBox5";
             this.groupBox5.TabStop = false;
             // 
@@ -262,6 +293,8 @@ namespace PoorMansTSqlFormatterDemo
             // 
             // grp_Options
             // 
+            resources.ApplyResources(this.grp_Options, "grp_Options");
+            this.grp_Options.Controls.Add(this.chk_ExpandSelectStatements);
             this.grp_Options.Controls.Add(this.chk_BreakJoinOnSections);
             this.grp_Options.Controls.Add(this.chk_ExpandInLists);
             this.grp_Options.Controls.Add(this.chk_EnableKeywordStandardization);
@@ -283,9 +316,17 @@ namespace PoorMansTSqlFormatterDemo
             this.grp_Options.Controls.Add(this.chk_ExpandBooleanExpressions);
             this.grp_Options.Controls.Add(this.chk_TrailingCommas);
             this.grp_Options.Controls.Add(this.chk_ExpandCommaLists);
-            resources.ApplyResources(this.grp_Options, "grp_Options");
             this.grp_Options.Name = "grp_Options";
             this.grp_Options.TabStop = false;
+            // 
+            // chk_ExpandSelectStatements
+            // 
+            resources.ApplyResources(this.chk_ExpandSelectStatements, "chk_ExpandSelectStatements");
+            this.chk_ExpandSelectStatements.Checked = true;
+            this.chk_ExpandSelectStatements.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chk_ExpandSelectStatements.Name = "chk_ExpandSelectStatements";
+            this.chk_ExpandSelectStatements.UseVisualStyleBackColor = true;
+            this.chk_ExpandSelectStatements.CheckedChanged += new System.EventHandler(this.FormatSettingsControlChanged);
             // 
             // chk_BreakJoinOnSections
             // 
@@ -435,8 +476,8 @@ namespace PoorMansTSqlFormatterDemo
             // 
             // grp_IdentityFormattingOptions
             // 
-            this.grp_IdentityFormattingOptions.Controls.Add(this.chk_IdentityColoring);
             resources.ApplyResources(this.grp_IdentityFormattingOptions, "grp_IdentityFormattingOptions");
+            this.grp_IdentityFormattingOptions.Controls.Add(this.chk_IdentityColoring);
             this.grp_IdentityFormattingOptions.Name = "grp_IdentityFormattingOptions";
             this.grp_IdentityFormattingOptions.TabStop = false;
             // 
@@ -458,12 +499,12 @@ namespace PoorMansTSqlFormatterDemo
             // 
             // grp_ObfuscationOptions
             // 
+            resources.ApplyResources(this.grp_ObfuscationOptions, "grp_ObfuscationOptions");
             this.grp_ObfuscationOptions.Controls.Add(this.chk_KeywordSubstitution);
             this.grp_ObfuscationOptions.Controls.Add(this.chk_PreserveComments);
             this.grp_ObfuscationOptions.Controls.Add(this.chk_RandomizeKeywordCase);
             this.grp_ObfuscationOptions.Controls.Add(this.chk_RandomizeLineLength);
             this.grp_ObfuscationOptions.Controls.Add(this.chk_RandomizeColor);
-            resources.ApplyResources(this.grp_ObfuscationOptions, "grp_ObfuscationOptions");
             this.grp_ObfuscationOptions.Name = "grp_ObfuscationOptions";
             this.grp_ObfuscationOptions.TabStop = false;
             // 
@@ -558,42 +599,6 @@ namespace PoorMansTSqlFormatterDemo
             this.languageToolStripMenuItem.Name = "languageToolStripMenuItem";
             resources.ApplyResources(this.languageToolStripMenuItem, "languageToolStripMenuItem");
             // 
-            // aboutToolStripMenuItem
-            // 
-            this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
-            resources.ApplyResources(this.aboutToolStripMenuItem, "aboutToolStripMenuItem");
-            this.aboutToolStripMenuItem.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
-            // 
-            // txt_Input
-            // 
-            this.txt_Input.AcceptsReturn = true;
-            this.txt_Input.AcceptsTab = true;
-            resources.ApplyResources(this.txt_Input, "txt_Input");
-            this.txt_Input.Name = "txt_Input";
-            this.txt_Input.TextChanged += new System.EventHandler(this.txt_Input_TextChanged);
-            // 
-            // txt_TokenizedSql
-            // 
-            this.txt_TokenizedSql.AcceptsReturn = true;
-            this.txt_TokenizedSql.AcceptsTab = true;
-            resources.ApplyResources(this.txt_TokenizedSql, "txt_TokenizedSql");
-            this.txt_TokenizedSql.Name = "txt_TokenizedSql";
-            this.txt_TokenizedSql.ReadOnly = true;
-            // 
-            // txt_ParsedXml
-            // 
-            this.txt_ParsedXml.AcceptsReturn = true;
-            this.txt_ParsedXml.AcceptsTab = true;
-            resources.ApplyResources(this.txt_ParsedXml, "txt_ParsedXml");
-            this.txt_ParsedXml.Name = "txt_ParsedXml";
-            this.txt_ParsedXml.ReadOnly = true;
-            // 
-            // webBrowser_OutputSql
-            // 
-            resources.ApplyResources(this.webBrowser_OutputSql, "webBrowser_OutputSql");
-            this.webBrowser_OutputSql.Name = "webBrowser_OutputSql";
-            this.webBrowser_OutputSql.ScriptErrorsSuppressed = true;
-            // 
             // englishToolStripMenuItem
             // 
             this.englishToolStripMenuItem.CheckOnClick = true;
@@ -614,6 +619,12 @@ namespace PoorMansTSqlFormatterDemo
             this.spanishToolStripMenuItem.Name = "spanishToolStripMenuItem";
             resources.ApplyResources(this.spanishToolStripMenuItem, "spanishToolStripMenuItem");
             this.spanishToolStripMenuItem.CheckedChanged += new System.EventHandler(this.languageSettingsHandler);
+            // 
+            // aboutToolStripMenuItem
+            // 
+            this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
+            resources.ApplyResources(this.aboutToolStripMenuItem, "aboutToolStripMenuItem");
+            this.aboutToolStripMenuItem.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
             // 
             // MainForm
             // 
@@ -640,10 +651,12 @@ namespace PoorMansTSqlFormatterDemo
             this.groupBox3.PerformLayout();
             this.splitContainer3.Panel1.ResumeLayout(false);
             this.splitContainer3.Panel2.ResumeLayout(false);
+            this.splitContainer3.Panel2.PerformLayout();
             this.splitContainer3.ResumeLayout(false);
             this.groupBox4.ResumeLayout(false);
             this.panel1.ResumeLayout(false);
             this.groupBox5.ResumeLayout(false);
+            this.groupBox5.PerformLayout();
             this.tableLayoutPanel2.ResumeLayout(false);
             this.tableLayoutPanel2.PerformLayout();
             this.grp_Options.ResumeLayout(false);
@@ -720,6 +733,7 @@ namespace PoorMansTSqlFormatterDemo
 		private System.Windows.Forms.Label lbl_ClauseBreaks;
 		private System.Windows.Forms.TextBox txt_StatementBreaks;
 		private System.Windows.Forms.Label lbl_StatementBreaks;
+        private System.Windows.Forms.CheckBox chk_ExpandSelectStatements;
     }
 }
 

--- a/PoorMansTSqlFormatterDemo/MainForm.cs
+++ b/PoorMansTSqlFormatterDemo/MainForm.cs
@@ -98,6 +98,7 @@ namespace PoorMansTSqlFormatterDemo
             chk_SpaceAfterComma.Checked = Properties.Settings.Default.SpaceAfterComma;
             chk_ExpandBooleanExpressions.Checked = Properties.Settings.Default.ExpandBooleanExpressions;
             chk_ExpandCaseStatements.Checked = Properties.Settings.Default.ExpandCaseStatements;
+            chk_ExpandSelectStatements.Checked = Properties.Settings.Default.ExpandSelectStatements;
 			chk_ExpandBetweenConditions.Checked = Properties.Settings.Default.ExpandBetweenConditions;
 			chk_ExpandInLists.Checked = Properties.Settings.Default.ExpandInLists;
 			chk_BreakJoinOnSections.Checked = Properties.Settings.Default.BreakJoinOnSections;
@@ -179,6 +180,7 @@ namespace PoorMansTSqlFormatterDemo
                         SpaceAfterExpandedComma = chk_SpaceAfterComma.Checked,
                         ExpandBooleanExpressions = chk_ExpandBooleanExpressions.Checked,
                         ExpandCaseStatements = chk_ExpandCaseStatements.Checked,
+                        ExpandSelectStatements= chk_ExpandSelectStatements.Checked,
 						ExpandBetweenConditions = chk_ExpandBetweenConditions.Checked,
 						ExpandInLists = chk_ExpandInLists.Checked,
 						BreakJoinOnSections = chk_BreakJoinOnSections.Checked,

--- a/PoorMansTSqlFormatterDemo/MainForm.resx
+++ b/PoorMansTSqlFormatterDemo/MainForm.resx
@@ -123,10 +123,7 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="splitContainer1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 42</value>
-  </data>
-  <data name="splitContainer1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>0, 24</value>
   </data>
   <data name="splitContainer1.Orientation" type="System.Windows.Forms.Orientation, System.Windows.Forms">
     <value>Horizontal</value>
@@ -137,9 +134,6 @@
   <data name="splitContainer4.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
-  <data name="splitContainer4.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
-  </data>
   <data name="txt_Input.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
@@ -147,10 +141,7 @@
     <value>Consolas, 9.75pt, style=Bold</value>
   </data>
   <data name="txt_Input.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 30</value>
-  </data>
-  <data name="txt_Input.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>3, 16</value>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="txt_Input.MaxLength" type="System.Int32, mscorlib">
@@ -163,7 +154,7 @@
     <value>Both</value>
   </data>
   <data name="txt_Input.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1052, 370</value>
+    <value>526, 157</value>
   </data>
   <data name="txt_Input.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -175,7 +166,7 @@
     <value>txt_Input</value>
   </data>
   <data name="&gt;&gt;txt_Input.Type" xml:space="preserve">
-    <value>PoorMansTSqlFormatterDemo.FrameworkClassReplacements.SelectableTextBox, PoorMansTSqlFormatterDemo, Version=1.6.6.128, Culture=neutral, PublicKeyToken=null</value>
+    <value>PoorMansTSqlFormatterDemo.FrameworkClassReplacements.SelectableTextBox, PoorMansTSqlFormatterDemo, Version=1.6.12.21718, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;txt_Input.Parent" xml:space="preserve">
     <value>groupBox1</value>
@@ -189,14 +180,8 @@
   <data name="groupBox1.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
-  <data name="groupBox1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
-  </data>
-  <data name="groupBox1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
-  </data>
   <data name="groupBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1064, 406</value>
+    <value>532, 176</value>
   </data>
   <data name="groupBox1.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -234,9 +219,6 @@
   <data name="splitContainer5.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
-  <data name="splitContainer5.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
-  </data>
   <data name="splitContainer5.Orientation" type="System.Windows.Forms.Orientation, System.Windows.Forms">
     <value>Horizontal</value>
   </data>
@@ -247,10 +229,7 @@
     <value>Courier New, 9.75pt</value>
   </data>
   <data name="txt_TokenizedSql.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 30</value>
-  </data>
-  <data name="txt_TokenizedSql.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>3, 16</value>
   </data>
   <data name="txt_TokenizedSql.Multiline" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -259,7 +238,7 @@
     <value>Both</value>
   </data>
   <data name="txt_TokenizedSql.Size" type="System.Drawing.Size, System.Drawing">
-    <value>900, 151</value>
+    <value>450, 62</value>
   </data>
   <data name="txt_TokenizedSql.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -271,7 +250,7 @@
     <value>txt_TokenizedSql</value>
   </data>
   <data name="&gt;&gt;txt_TokenizedSql.Type" xml:space="preserve">
-    <value>PoorMansTSqlFormatterDemo.FrameworkClassReplacements.SelectableTextBox, PoorMansTSqlFormatterDemo, Version=1.6.6.128, Culture=neutral, PublicKeyToken=null</value>
+    <value>PoorMansTSqlFormatterDemo.FrameworkClassReplacements.SelectableTextBox, PoorMansTSqlFormatterDemo, Version=1.6.12.21718, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;txt_TokenizedSql.Parent" xml:space="preserve">
     <value>groupBox2</value>
@@ -285,14 +264,8 @@
   <data name="groupBox2.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
-  <data name="groupBox2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
-  </data>
-  <data name="groupBox2.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
-  </data>
   <data name="groupBox2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>912, 187</value>
+    <value>456, 81</value>
   </data>
   <data name="groupBox2.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -331,10 +304,7 @@
     <value>Courier New, 9.75pt</value>
   </data>
   <data name="txt_ParsedXml.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 30</value>
-  </data>
-  <data name="txt_ParsedXml.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>3, 16</value>
   </data>
   <data name="txt_ParsedXml.Multiline" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -343,7 +313,7 @@
     <value>Both</value>
   </data>
   <data name="txt_ParsedXml.Size" type="System.Drawing.Size, System.Drawing">
-    <value>900, 175</value>
+    <value>450, 72</value>
   </data>
   <data name="txt_ParsedXml.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -355,7 +325,7 @@
     <value>txt_ParsedXml</value>
   </data>
   <data name="&gt;&gt;txt_ParsedXml.Type" xml:space="preserve">
-    <value>PoorMansTSqlFormatterDemo.FrameworkClassReplacements.SelectableTextBox, PoorMansTSqlFormatterDemo, Version=1.6.6.128, Culture=neutral, PublicKeyToken=null</value>
+    <value>PoorMansTSqlFormatterDemo.FrameworkClassReplacements.SelectableTextBox, PoorMansTSqlFormatterDemo, Version=1.6.12.21718, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;txt_ParsedXml.Parent" xml:space="preserve">
     <value>groupBox3</value>
@@ -369,14 +339,8 @@
   <data name="groupBox3.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
-  <data name="groupBox3.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
-  </data>
-  <data name="groupBox3.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
-  </data>
   <data name="groupBox3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>912, 211</value>
+    <value>456, 91</value>
   </data>
   <data name="groupBox3.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -409,13 +373,10 @@
     <value>1</value>
   </data>
   <data name="splitContainer5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>912, 406</value>
+    <value>456, 176</value>
   </data>
   <data name="splitContainer5.SplitterDistance" type="System.Int32, mscorlib">
-    <value>187</value>
-  </data>
-  <data name="splitContainer5.SplitterWidth" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>81</value>
   </data>
   <data name="splitContainer5.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -445,13 +406,10 @@
     <value>1</value>
   </data>
   <data name="splitContainer4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1984, 406</value>
+    <value>992, 176</value>
   </data>
   <data name="splitContainer4.SplitterDistance" type="System.Int32, mscorlib">
-    <value>1064</value>
-  </data>
-  <data name="splitContainer4.SplitterWidth" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>532</value>
   </data>
   <data name="splitContainer4.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -489,23 +447,17 @@
   <data name="splitContainer3.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
-  <data name="splitContainer3.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
-  </data>
   <data name="webBrowser_OutputSql.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
   <data name="webBrowser_OutputSql.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
-  <data name="webBrowser_OutputSql.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
-  </data>
   <data name="webBrowser_OutputSql.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>40, 39</value>
+    <value>20, 20</value>
   </data>
   <data name="webBrowser_OutputSql.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1402, 760</value>
+    <value>699, 325</value>
   </data>
   <data name="webBrowser_OutputSql.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -514,7 +466,7 @@
     <value>webBrowser_OutputSql</value>
   </data>
   <data name="&gt;&gt;webBrowser_OutputSql.Type" xml:space="preserve">
-    <value>PoorMansTSqlFormatterDemo.FrameworkClassReplacements.CustomContentWebBrowser, PoorMansTSqlFormatterDemo, Version=1.6.6.128, Culture=neutral, PublicKeyToken=null</value>
+    <value>PoorMansTSqlFormatterDemo.FrameworkClassReplacements.CustomContentWebBrowser, PoorMansTSqlFormatterDemo, Version=1.6.12.21718, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;webBrowser_OutputSql.Parent" xml:space="preserve">
     <value>panel1</value>
@@ -526,13 +478,10 @@
     <value>Fill</value>
   </data>
   <data name="panel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 30</value>
-  </data>
-  <data name="panel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>3, 16</value>
   </data>
   <data name="panel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1406, 764</value>
+    <value>703, 329</value>
   </data>
   <data name="panel1.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -555,14 +504,8 @@
   <data name="groupBox4.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
-  <data name="groupBox4.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
-  </data>
-  <data name="groupBox4.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
-  </data>
   <data name="groupBox4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1418, 800</value>
+    <value>709, 348</value>
   </data>
   <data name="groupBox4.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -597,7 +540,13 @@
   <data name="splitContainer3.Panel2.AutoScroll" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <data name="groupBox5.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <data name="tableLayoutPanel2.AutoScroll" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="tableLayoutPanel2.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="tableLayoutPanel2.ColumnCount" type="System.Int32, mscorlib">
@@ -610,13 +559,10 @@
     <value>NoControl</value>
   </data>
   <data name="radio_Formatting_Identity.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 646</value>
-  </data>
-  <data name="radio_Formatting_Identity.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>3, 441</value>
   </data>
   <data name="radio_Formatting_Identity.Size" type="System.Drawing.Size, System.Drawing">
-    <value>324, 29</value>
+    <value>159, 17</value>
   </data>
   <data name="radio_Formatting_Identity.TabIndex" type="System.Int32, mscorlib">
     <value>21</value>
@@ -643,13 +589,10 @@
     <value>NoControl</value>
   </data>
   <data name="radio_Formatting_Standard.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 6</value>
-  </data>
-  <data name="radio_Formatting_Standard.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>3, 3</value>
   </data>
   <data name="radio_Formatting_Standard.Size" type="System.Drawing.Size, System.Drawing">
-    <value>238, 29</value>
+    <value>120, 17</value>
   </data>
   <data name="radio_Formatting_Standard.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -669,6 +612,39 @@
   <data name="&gt;&gt;radio_Formatting_Standard.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="grp_Options.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chk_ExpandSelectStatements.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chk_ExpandSelectStatements.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="chk_ExpandSelectStatements.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 373</value>
+  </data>
+  <data name="chk_ExpandSelectStatements.Size" type="System.Drawing.Size, System.Drawing">
+    <value>162, 17</value>
+  </data>
+  <data name="chk_ExpandSelectStatements.TabIndex" type="System.Int32, mscorlib">
+    <value>21</value>
+  </data>
+  <data name="chk_ExpandSelectStatements.Text" xml:space="preserve">
+    <value>Expand SELECT Statements</value>
+  </data>
+  <data name="&gt;&gt;chk_ExpandSelectStatements.Name" xml:space="preserve">
+    <value>chk_ExpandSelectStatements</value>
+  </data>
+  <data name="&gt;&gt;chk_ExpandSelectStatements.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chk_ExpandSelectStatements.Parent" xml:space="preserve">
+    <value>grp_Options</value>
+  </data>
+  <data name="&gt;&gt;chk_ExpandSelectStatements.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="chk_BreakJoinOnSections.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -676,13 +652,10 @@
     <value>NoControl</value>
   </data>
   <data name="chk_BreakJoinOnSections.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 541</value>
-  </data>
-  <data name="chk_BreakJoinOnSections.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>8, 281</value>
   </data>
   <data name="chk_BreakJoinOnSections.Size" type="System.Drawing.Size, System.Drawing">
-    <value>272, 29</value>
+    <value>139, 17</value>
   </data>
   <data name="chk_BreakJoinOnSections.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -700,7 +673,7 @@
     <value>grp_Options</value>
   </data>
   <data name="&gt;&gt;chk_BreakJoinOnSections.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="chk_ExpandInLists.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -709,13 +682,10 @@
     <value>NoControl</value>
   </data>
   <data name="chk_ExpandInLists.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 495</value>
-  </data>
-  <data name="chk_ExpandInLists.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>8, 257</value>
   </data>
   <data name="chk_ExpandInLists.Size" type="System.Drawing.Size, System.Drawing">
-    <value>194, 29</value>
+    <value>100, 17</value>
   </data>
   <data name="chk_ExpandInLists.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -733,7 +703,7 @@
     <value>grp_Options</value>
   </data>
   <data name="&gt;&gt;chk_ExpandInLists.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="chk_EnableKeywordStandardization.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -742,13 +712,10 @@
     <value>NoControl</value>
   </data>
   <data name="chk_EnableKeywordStandardization.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 673</value>
-  </data>
-  <data name="chk_EnableKeywordStandardization.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>8, 350</value>
   </data>
   <data name="chk_EnableKeywordStandardization.Size" type="System.Drawing.Size, System.Drawing">
-    <value>356, 29</value>
+    <value>179, 17</value>
   </data>
   <data name="chk_EnableKeywordStandardization.TabIndex" type="System.Int32, mscorlib">
     <value>20</value>
@@ -766,16 +733,13 @@
     <value>grp_Options</value>
   </data>
   <data name="&gt;&gt;chk_EnableKeywordStandardization.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="txt_ClauseBreaks.Location" type="System.Drawing.Point, System.Drawing">
-    <value>231, 183</value>
-  </data>
-  <data name="txt_ClauseBreaks.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>116, 95</value>
   </data>
   <data name="txt_ClauseBreaks.Size" type="System.Drawing.Size, System.Drawing">
-    <value>73, 31</value>
+    <value>38, 20</value>
   </data>
   <data name="txt_ClauseBreaks.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -793,7 +757,7 @@
     <value>grp_Options</value>
   </data>
   <data name="&gt;&gt;txt_ClauseBreaks.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="lbl_ClauseBreaks.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -802,13 +766,10 @@
     <value>NoControl</value>
   </data>
   <data name="lbl_ClauseBreaks.Location" type="System.Drawing.Point, System.Drawing">
-    <value>14, 188</value>
-  </data>
-  <data name="lbl_ClauseBreaks.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 0, 6, 0</value>
+    <value>7, 98</value>
   </data>
   <data name="lbl_ClauseBreaks.Size" type="System.Drawing.Size, System.Drawing">
-    <value>158, 25</value>
+    <value>78, 13</value>
   </data>
   <data name="lbl_ClauseBreaks.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -826,16 +787,13 @@
     <value>grp_Options</value>
   </data>
   <data name="&gt;&gt;lbl_ClauseBreaks.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="txt_StatementBreaks.Location" type="System.Drawing.Point, System.Drawing">
-    <value>231, 136</value>
-  </data>
-  <data name="txt_StatementBreaks.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>116, 71</value>
   </data>
   <data name="txt_StatementBreaks.Size" type="System.Drawing.Size, System.Drawing">
-    <value>73, 31</value>
+    <value>38, 20</value>
   </data>
   <data name="txt_StatementBreaks.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -853,7 +811,7 @@
     <value>grp_Options</value>
   </data>
   <data name="&gt;&gt;txt_StatementBreaks.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>6</value>
   </data>
   <data name="lbl_StatementBreaks.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -862,13 +820,10 @@
     <value>NoControl</value>
   </data>
   <data name="lbl_StatementBreaks.Location" type="System.Drawing.Point, System.Drawing">
-    <value>14, 141</value>
-  </data>
-  <data name="lbl_StatementBreaks.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 0, 6, 0</value>
+    <value>7, 73</value>
   </data>
   <data name="lbl_StatementBreaks.Size" type="System.Drawing.Size, System.Drawing">
-    <value>188, 25</value>
+    <value>94, 13</value>
   </data>
   <data name="lbl_StatementBreaks.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -886,16 +841,13 @@
     <value>grp_Options</value>
   </data>
   <data name="&gt;&gt;lbl_StatementBreaks.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>7</value>
   </data>
   <data name="txt_MaxWidth.Location" type="System.Drawing.Point, System.Drawing">
-    <value>154, 89</value>
-  </data>
-  <data name="txt_MaxWidth.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>77, 46</value>
   </data>
   <data name="txt_MaxWidth.Size" type="System.Drawing.Size, System.Drawing">
-    <value>150, 31</value>
+    <value>77, 20</value>
   </data>
   <data name="txt_MaxWidth.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -913,7 +865,7 @@
     <value>grp_Options</value>
   </data>
   <data name="&gt;&gt;txt_MaxWidth.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>8</value>
   </data>
   <data name="lbl_MaxWidth.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -922,13 +874,10 @@
     <value>NoControl</value>
   </data>
   <data name="lbl_MaxWidth.Location" type="System.Drawing.Point, System.Drawing">
-    <value>14, 94</value>
-  </data>
-  <data name="lbl_MaxWidth.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 0, 6, 0</value>
+    <value>7, 49</value>
   </data>
   <data name="lbl_MaxWidth.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 25</value>
+    <value>61, 13</value>
   </data>
   <data name="lbl_MaxWidth.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -946,16 +895,13 @@
     <value>grp_Options</value>
   </data>
   <data name="&gt;&gt;lbl_MaxWidth.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>9</value>
   </data>
   <data name="txt_IndentWidth.Location" type="System.Drawing.Point, System.Drawing">
-    <value>320, 39</value>
-  </data>
-  <data name="txt_IndentWidth.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>160, 20</value>
   </data>
   <data name="txt_IndentWidth.Size" type="System.Drawing.Size, System.Drawing">
-    <value>62, 31</value>
+    <value>33, 20</value>
   </data>
   <data name="txt_IndentWidth.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -973,7 +919,7 @@
     <value>grp_Options</value>
   </data>
   <data name="&gt;&gt;txt_IndentWidth.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>10</value>
   </data>
   <data name="lbl_IndentWidth.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -982,13 +928,10 @@
     <value>NoControl</value>
   </data>
   <data name="lbl_IndentWidth.Location" type="System.Drawing.Point, System.Drawing">
-    <value>166, 44</value>
-  </data>
-  <data name="lbl_IndentWidth.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 0, 6, 0</value>
+    <value>83, 23</value>
   </data>
   <data name="lbl_IndentWidth.Size" type="System.Drawing.Size, System.Drawing">
-    <value>138, 25</value>
+    <value>71, 13</value>
   </data>
   <data name="lbl_IndentWidth.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -1006,16 +949,13 @@
     <value>grp_Options</value>
   </data>
   <data name="&gt;&gt;lbl_IndentWidth.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>11</value>
   </data>
   <data name="txt_Indent.Location" type="System.Drawing.Point, System.Drawing">
-    <value>94, 39</value>
-  </data>
-  <data name="txt_Indent.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>47, 20</value>
   </data>
   <data name="txt_Indent.Size" type="System.Drawing.Size, System.Drawing">
-    <value>62, 31</value>
+    <value>33, 20</value>
   </data>
   <data name="txt_Indent.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -1033,7 +973,7 @@
     <value>grp_Options</value>
   </data>
   <data name="&gt;&gt;txt_Indent.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>12</value>
   </data>
   <data name="lbl_Indent.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1042,13 +982,10 @@
     <value>NoControl</value>
   </data>
   <data name="lbl_Indent.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 44</value>
-  </data>
-  <data name="lbl_Indent.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 0, 6, 0</value>
+    <value>6, 23</value>
   </data>
   <data name="lbl_Indent.Size" type="System.Drawing.Size, System.Drawing">
-    <value>77, 25</value>
+    <value>40, 13</value>
   </data>
   <data name="lbl_Indent.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -1066,7 +1003,7 @@
     <value>grp_Options</value>
   </data>
   <data name="&gt;&gt;lbl_Indent.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>13</value>
   </data>
   <data name="chk_ExpandBetweenConditions.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1075,13 +1012,10 @@
     <value>NoControl</value>
   </data>
   <data name="chk_ExpandBetweenConditions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>18, 450</value>
-  </data>
-  <data name="chk_ExpandBetweenConditions.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>9, 234</value>
   </data>
   <data name="chk_ExpandBetweenConditions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>335, 29</value>
+    <value>171, 17</value>
   </data>
   <data name="chk_ExpandBetweenConditions.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -1099,7 +1033,7 @@
     <value>grp_Options</value>
   </data>
   <data name="&gt;&gt;chk_ExpandBetweenConditions.ZOrder" xml:space="preserve">
-    <value>13</value>
+    <value>14</value>
   </data>
   <data name="chk_SpaceAfterComma.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1108,13 +1042,10 @@
     <value>NoControl</value>
   </data>
   <data name="chk_SpaceAfterComma.Location" type="System.Drawing.Point, System.Drawing">
-    <value>84, 317</value>
-  </data>
-  <data name="chk_SpaceAfterComma.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>42, 165</value>
   </data>
   <data name="chk_SpaceAfterComma.Size" type="System.Drawing.Size, System.Drawing">
-    <value>235, 29</value>
+    <value>120, 17</value>
   </data>
   <data name="chk_SpaceAfterComma.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -1132,7 +1063,7 @@
     <value>grp_Options</value>
   </data>
   <data name="&gt;&gt;chk_SpaceAfterComma.ZOrder" xml:space="preserve">
-    <value>14</value>
+    <value>15</value>
   </data>
   <data name="chk_Coloring.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1141,13 +1072,10 @@
     <value>NoControl</value>
   </data>
   <data name="chk_Coloring.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 628</value>
-  </data>
-  <data name="chk_Coloring.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>8, 327</value>
   </data>
   <data name="chk_Coloring.Size" type="System.Drawing.Size, System.Drawing">
-    <value>197, 29</value>
+    <value>100, 17</value>
   </data>
   <data name="chk_Coloring.TabIndex" type="System.Int32, mscorlib">
     <value>19</value>
@@ -1165,7 +1093,7 @@
     <value>grp_Options</value>
   </data>
   <data name="&gt;&gt;chk_Coloring.ZOrder" xml:space="preserve">
-    <value>15</value>
+    <value>16</value>
   </data>
   <data name="chk_UppercaseKeywords.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1174,13 +1102,10 @@
     <value>NoControl</value>
   </data>
   <data name="chk_UppercaseKeywords.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 584</value>
-  </data>
-  <data name="chk_UppercaseKeywords.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>8, 304</value>
   </data>
   <data name="chk_UppercaseKeywords.Size" type="System.Drawing.Size, System.Drawing">
-    <value>248, 29</value>
+    <value>127, 17</value>
   </data>
   <data name="chk_UppercaseKeywords.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
@@ -1198,7 +1123,7 @@
     <value>grp_Options</value>
   </data>
   <data name="&gt;&gt;chk_UppercaseKeywords.ZOrder" xml:space="preserve">
-    <value>16</value>
+    <value>17</value>
   </data>
   <data name="chk_ExpandCaseStatements.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1207,13 +1132,10 @@
     <value>NoControl</value>
   </data>
   <data name="chk_ExpandCaseStatements.Location" type="System.Drawing.Point, System.Drawing">
-    <value>18, 406</value>
-  </data>
-  <data name="chk_ExpandCaseStatements.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>9, 211</value>
   </data>
   <data name="chk_ExpandCaseStatements.Size" type="System.Drawing.Size, System.Drawing">
-    <value>294, 29</value>
+    <value>149, 17</value>
   </data>
   <data name="chk_ExpandCaseStatements.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -1231,7 +1153,7 @@
     <value>grp_Options</value>
   </data>
   <data name="&gt;&gt;chk_ExpandCaseStatements.ZOrder" xml:space="preserve">
-    <value>17</value>
+    <value>18</value>
   </data>
   <data name="chk_ExpandBooleanExpressions.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1240,13 +1162,10 @@
     <value>NoControl</value>
   </data>
   <data name="chk_ExpandBooleanExpressions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>18, 362</value>
-  </data>
-  <data name="chk_ExpandBooleanExpressions.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>9, 188</value>
   </data>
   <data name="chk_ExpandBooleanExpressions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>326, 29</value>
+    <value>163, 17</value>
   </data>
   <data name="chk_ExpandBooleanExpressions.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -1264,7 +1183,7 @@
     <value>grp_Options</value>
   </data>
   <data name="&gt;&gt;chk_ExpandBooleanExpressions.ZOrder" xml:space="preserve">
-    <value>18</value>
+    <value>19</value>
   </data>
   <data name="chk_TrailingCommas.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1273,13 +1192,10 @@
     <value>NoControl</value>
   </data>
   <data name="chk_TrailingCommas.Location" type="System.Drawing.Point, System.Drawing">
-    <value>84, 273</value>
-  </data>
-  <data name="chk_TrailingCommas.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>42, 142</value>
   </data>
   <data name="chk_TrailingCommas.Size" type="System.Drawing.Size, System.Drawing">
-    <value>205, 29</value>
+    <value>103, 17</value>
   </data>
   <data name="chk_TrailingCommas.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -1297,7 +1213,7 @@
     <value>grp_Options</value>
   </data>
   <data name="&gt;&gt;chk_TrailingCommas.ZOrder" xml:space="preserve">
-    <value>19</value>
+    <value>20</value>
   </data>
   <data name="chk_ExpandCommaLists.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1306,13 +1222,10 @@
     <value>NoControl</value>
   </data>
   <data name="chk_ExpandCommaLists.Location" type="System.Drawing.Point, System.Drawing">
-    <value>18, 230</value>
-  </data>
-  <data name="chk_ExpandCommaLists.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>9, 120</value>
   </data>
   <data name="chk_ExpandCommaLists.Size" type="System.Drawing.Size, System.Drawing">
-    <value>247, 29</value>
+    <value>124, 17</value>
   </data>
   <data name="chk_ExpandCommaLists.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -1330,22 +1243,16 @@
     <value>grp_Options</value>
   </data>
   <data name="&gt;&gt;chk_ExpandCommaLists.ZOrder" xml:space="preserve">
-    <value>20</value>
+    <value>21</value>
   </data>
   <data name="grp_Options.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
   <data name="grp_Options.Location" type="System.Drawing.Point, System.Drawing">
-    <value>86, 54</value>
-  </data>
-  <data name="grp_Options.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
-  </data>
-  <data name="grp_Options.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>43, 26</value>
   </data>
   <data name="grp_Options.Size" type="System.Drawing.Size, System.Drawing">
-    <value>420, 580</value>
+    <value>210, 409</value>
   </data>
   <data name="grp_Options.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -1365,6 +1272,9 @@
   <data name="&gt;&gt;grp_Options.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
+  <data name="grp_IdentityFormattingOptions.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <data name="chk_IdentityColoring.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -1372,13 +1282,10 @@
     <value>NoControl</value>
   </data>
   <data name="chk_IdentityColoring.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 36</value>
-  </data>
-  <data name="chk_IdentityColoring.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>6, 19</value>
   </data>
   <data name="chk_IdentityColoring.Size" type="System.Drawing.Size, System.Drawing">
-    <value>197, 29</value>
+    <value>100, 17</value>
   </data>
   <data name="chk_IdentityColoring.TabIndex" type="System.Int32, mscorlib">
     <value>22</value>
@@ -1398,17 +1305,14 @@
   <data name="&gt;&gt;chk_IdentityColoring.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
+  <data name="grp_IdentityFormattingOptions.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
   <data name="grp_IdentityFormattingOptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>86, 694</value>
-  </data>
-  <data name="grp_IdentityFormattingOptions.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
-  </data>
-  <data name="grp_IdentityFormattingOptions.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>43, 464</value>
   </data>
   <data name="grp_IdentityFormattingOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>398, 81</value>
+    <value>210, 55</value>
   </data>
   <data name="grp_IdentityFormattingOptions.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -1435,13 +1339,10 @@
     <value>NoControl</value>
   </data>
   <data name="radio_Formatting_Obfuscate.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 789</value>
-  </data>
-  <data name="radio_Formatting_Obfuscate.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>3, 525</value>
   </data>
   <data name="radio_Formatting_Obfuscate.Size" type="System.Drawing.Size, System.Drawing">
-    <value>285, 29</value>
+    <value>146, 17</value>
   </data>
   <data name="radio_Formatting_Obfuscate.TabIndex" type="System.Int32, mscorlib">
     <value>23</value>
@@ -1461,6 +1362,9 @@
   <data name="&gt;&gt;radio_Formatting_Obfuscate.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
+  <data name="grp_ObfuscationOptions.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <data name="chk_KeywordSubstitution.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -1468,13 +1372,10 @@
     <value>NoControl</value>
   </data>
   <data name="chk_KeywordSubstitution.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 216</value>
-  </data>
-  <data name="chk_KeywordSubstitution.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>6, 112</value>
   </data>
   <data name="chk_KeywordSubstitution.Size" type="System.Drawing.Size, System.Drawing">
-    <value>246, 29</value>
+    <value>125, 17</value>
   </data>
   <data name="chk_KeywordSubstitution.TabIndex" type="System.Int32, mscorlib">
     <value>28</value>
@@ -1501,13 +1402,10 @@
     <value>NoControl</value>
   </data>
   <data name="chk_PreserveComments.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 172</value>
-  </data>
-  <data name="chk_PreserveComments.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>6, 89</value>
   </data>
   <data name="chk_PreserveComments.Size" type="System.Drawing.Size, System.Drawing">
-    <value>238, 29</value>
+    <value>120, 17</value>
   </data>
   <data name="chk_PreserveComments.TabIndex" type="System.Int32, mscorlib">
     <value>27</value>
@@ -1534,13 +1432,10 @@
     <value>NoControl</value>
   </data>
   <data name="chk_RandomizeKeywordCase.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 126</value>
-  </data>
-  <data name="chk_RandomizeKeywordCase.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>6, 66</value>
   </data>
   <data name="chk_RandomizeKeywordCase.Size" type="System.Drawing.Size, System.Drawing">
-    <value>297, 29</value>
+    <value>150, 17</value>
   </data>
   <data name="chk_RandomizeKeywordCase.TabIndex" type="System.Int32, mscorlib">
     <value>26</value>
@@ -1567,13 +1462,10 @@
     <value>NoControl</value>
   </data>
   <data name="chk_RandomizeLineLength.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 83</value>
-  </data>
-  <data name="chk_RandomizeLineLength.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>6, 43</value>
   </data>
   <data name="chk_RandomizeLineLength.Size" type="System.Drawing.Size, System.Drawing">
-    <value>282, 29</value>
+    <value>143, 17</value>
   </data>
   <data name="chk_RandomizeLineLength.TabIndex" type="System.Int32, mscorlib">
     <value>25</value>
@@ -1600,13 +1492,10 @@
     <value>NoControl</value>
   </data>
   <data name="chk_RandomizeColor.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 39</value>
-  </data>
-  <data name="chk_RandomizeColor.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>6, 20</value>
   </data>
   <data name="chk_RandomizeColor.Size" type="System.Drawing.Size, System.Drawing">
-    <value>209, 29</value>
+    <value>106, 17</value>
   </data>
   <data name="chk_RandomizeColor.TabIndex" type="System.Int32, mscorlib">
     <value>24</value>
@@ -1626,17 +1515,14 @@
   <data name="&gt;&gt;chk_RandomizeColor.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
+  <data name="grp_ObfuscationOptions.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
   <data name="grp_ObfuscationOptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>86, 837</value>
-  </data>
-  <data name="grp_ObfuscationOptions.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
-  </data>
-  <data name="grp_ObfuscationOptions.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>43, 548</value>
   </data>
   <data name="grp_ObfuscationOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>400, 274</value>
+    <value>210, 148</value>
   </data>
   <data name="grp_ObfuscationOptions.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -1660,16 +1546,13 @@
     <value>Top</value>
   </data>
   <data name="tableLayoutPanel2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 30</value>
-  </data>
-  <data name="tableLayoutPanel2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>3, 16</value>
   </data>
   <data name="tableLayoutPanel2.RowCount" type="System.Int32, mscorlib">
     <value>6</value>
   </data>
   <data name="tableLayoutPanel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>512, 1200</value>
+    <value>256, 699</value>
   </data>
   <data name="tableLayoutPanel2.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -1687,7 +1570,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel2.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="radio_Formatting_Identity" Row="2" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="radio_Formatting_Standard" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="grp_Options" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="grp_IdentityFormattingOptions" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="radio_Formatting_Obfuscate" Row="4" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="grp_ObfuscationOptions" Row="5" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Absolute,80,Percent,100" /&gt;&lt;Rows Styles="Absolute,48,Absolute,592,Absolute,48,Absolute,95,Absolute,48,Absolute,280" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="radio_Formatting_Identity" Row="2" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="radio_Formatting_Standard" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="grp_Options" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="grp_IdentityFormattingOptions" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="radio_Formatting_Obfuscate" Row="4" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="grp_ObfuscationOptions" Row="5" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Absolute,40,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="groupBox5.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
@@ -1695,17 +1578,11 @@
   <data name="groupBox5.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
-  <data name="groupBox5.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
-  </data>
   <data name="groupBox5.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>476, 1116</value>
-  </data>
-  <data name="groupBox5.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>238, 580</value>
   </data>
   <data name="groupBox5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>524, 1250</value>
+    <value>262, 718</value>
   </data>
   <data name="groupBox5.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -1738,13 +1615,10 @@
     <value>1</value>
   </data>
   <data name="splitContainer3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1984, 800</value>
+    <value>992, 348</value>
   </data>
   <data name="splitContainer3.SplitterDistance" type="System.Int32, mscorlib">
-    <value>1418</value>
-  </data>
-  <data name="splitContainer3.SplitterWidth" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>709</value>
   </data>
   <data name="splitContainer3.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -1774,13 +1648,10 @@
     <value>1</value>
   </data>
   <data name="splitContainer1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1984, 1214</value>
+    <value>992, 528</value>
   </data>
   <data name="splitContainer1.SplitterDistance" type="System.Int32, mscorlib">
-    <value>406</value>
-  </data>
-  <data name="splitContainer1.SplitterWidth" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>176</value>
   </data>
   <data name="splitContainer1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -1804,55 +1675,55 @@
     <value>0, 0</value>
   </metadata>
   <data name="displayTokenListToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>461, 38</value>
+    <value>246, 22</value>
   </data>
   <data name="displayTokenListToolStripMenuItem.Text" xml:space="preserve">
     <value>Display Token List Area</value>
   </data>
   <data name="displayParsedSqlToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>461, 38</value>
+    <value>246, 22</value>
   </data>
   <data name="displayParsedSqlToolStripMenuItem.Text" xml:space="preserve">
     <value>Display Parsed SQL (Xml) Area</value>
   </data>
   <data name="displayFormattingOptionsAreaToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>461, 38</value>
+    <value>246, 22</value>
   </data>
   <data name="displayFormattingOptionsAreaToolStripMenuItem.Text" xml:space="preserve">
     <value>Display Formatting Options Area</value>
   </data>
   <data name="englishToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>197, 38</value>
+    <value>115, 22</value>
   </data>
   <data name="englishToolStripMenuItem.Text" xml:space="preserve">
     <value>English</value>
   </data>
   <data name="frenchToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>197, 38</value>
+    <value>115, 22</value>
   </data>
   <data name="frenchToolStripMenuItem.Text" xml:space="preserve">
     <value>French</value>
   </data>
   <data name="spanishToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>197, 38</value>
+    <value>115, 22</value>
   </data>
   <data name="spanishToolStripMenuItem.Text" xml:space="preserve">
     <value>Spanish</value>
   </data>
   <data name="languageToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>461, 38</value>
+    <value>246, 22</value>
   </data>
   <data name="languageToolStripMenuItem.Text" xml:space="preserve">
     <value>Language</value>
   </data>
   <data name="optionsToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>111, 36</value>
+    <value>61, 20</value>
   </data>
   <data name="optionsToolStripMenuItem.Text" xml:space="preserve">
     <value>Options</value>
   </data>
   <data name="aboutToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>92, 36</value>
+    <value>52, 20</value>
   </data>
   <data name="aboutToolStripMenuItem.Text" xml:space="preserve">
     <value>About</value>
@@ -1860,11 +1731,8 @@
   <data name="menuStrip1.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
-  <data name="menuStrip1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>12, 3, 0, 3</value>
-  </data>
   <data name="menuStrip1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1984, 42</value>
+    <value>992, 24</value>
   </data>
   <data name="menuStrip1.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -1888,19 +1756,13 @@
     <value>True</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>34</value>
+    <value>25</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>12, 25</value>
+    <value>6, 13</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>1984, 1256</value>
-  </data>
-  <data name="$this.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>992, 552</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
     <value>SQL Formatter</value>
@@ -1941,29 +1803,29 @@
   <data name="&gt;&gt;languageToolStripMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;aboutToolStripMenuItem.Name" xml:space="preserve">
-    <value>aboutToolStripMenuItem</value>
-  </data>
-  <data name="&gt;&gt;aboutToolStripMenuItem.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
   <data name="&gt;&gt;englishToolStripMenuItem.Name" xml:space="preserve">
     <value>englishToolStripMenuItem</value>
   </data>
   <data name="&gt;&gt;englishToolStripMenuItem.Type" xml:space="preserve">
-    <value>PoorMansTSqlFormatterDemo.FrameworkClassReplacements.RadioToolStripMenuItem, PoorMansTSqlFormatterDemo, Version=1.6.6.128, Culture=neutral, PublicKeyToken=null</value>
+    <value>PoorMansTSqlFormatterDemo.FrameworkClassReplacements.RadioToolStripMenuItem, PoorMansTSqlFormatterDemo, Version=1.6.12.21718, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;frenchToolStripMenuItem.Name" xml:space="preserve">
     <value>frenchToolStripMenuItem</value>
   </data>
   <data name="&gt;&gt;frenchToolStripMenuItem.Type" xml:space="preserve">
-    <value>PoorMansTSqlFormatterDemo.FrameworkClassReplacements.RadioToolStripMenuItem, PoorMansTSqlFormatterDemo, Version=1.6.6.128, Culture=neutral, PublicKeyToken=null</value>
+    <value>PoorMansTSqlFormatterDemo.FrameworkClassReplacements.RadioToolStripMenuItem, PoorMansTSqlFormatterDemo, Version=1.6.12.21718, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;spanishToolStripMenuItem.Name" xml:space="preserve">
     <value>spanishToolStripMenuItem</value>
   </data>
   <data name="&gt;&gt;spanishToolStripMenuItem.Type" xml:space="preserve">
-    <value>PoorMansTSqlFormatterDemo.FrameworkClassReplacements.RadioToolStripMenuItem, PoorMansTSqlFormatterDemo, Version=1.6.6.128, Culture=neutral, PublicKeyToken=null</value>
+    <value>PoorMansTSqlFormatterDemo.FrameworkClassReplacements.RadioToolStripMenuItem, PoorMansTSqlFormatterDemo, Version=1.6.12.21718, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;aboutToolStripMenuItem.Name" xml:space="preserve">
+    <value>aboutToolStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;aboutToolStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>MainForm</value>

--- a/PoorMansTSqlFormatterDemo/PoorMansTSqlFormatterDemo.csproj
+++ b/PoorMansTSqlFormatterDemo/PoorMansTSqlFormatterDemo.csproj
@@ -45,13 +45,21 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="AboutBox.cs" />
+    <Compile Include="AboutBox.cs">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="AboutBox.designer.cs">
       <DependentUpon>AboutBox.cs</DependentUpon>
     </Compile>
-    <Compile Include="FrameworkClassReplacements\CustomContentWebBrowser.cs" />
-    <Compile Include="FrameworkClassReplacements\RadioToolStripMenuItem.cs" />
-    <Compile Include="FrameworkClassReplacements\SelectableTextBox.cs" />
+    <Compile Include="FrameworkClassReplacements\CustomContentWebBrowser.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Include="FrameworkClassReplacements\RadioToolStripMenuItem.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Include="FrameworkClassReplacements\SelectableTextBox.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="FrameworkClassReplacements\SingleAssemblyComponentResourceManager.cs" />
     <Compile Include="FrameworkClassReplacements\SingleAssemblyResourceManager.cs" />
     <Compile Include="GeneralLanguageContent.Designer.cs">
@@ -59,7 +67,9 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>GeneralLanguageContent.resx</DependentUpon>
     </Compile>
-    <Compile Include="MainForm.cs" />
+    <Compile Include="MainForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="MainForm.Designer.cs">
       <DependentUpon>MainForm.cs</DependentUpon>
     </Compile>

--- a/PoorMansTSqlFormatterDemo/Properties/Settings.Designer.cs
+++ b/PoorMansTSqlFormatterDemo/Properties/Settings.Designer.cs
@@ -205,6 +205,21 @@ namespace PoorMansTSqlFormatterDemo.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool ExpandSelectStatements
+        {
+            get
+            {
+                return ((bool)(this["ExpandSelectStatements"]));
+            }
+            set
+            {
+                this["ExpandSelectStatements"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("True")]
         public bool ExpandBetweenConditions {
             get {

--- a/PoorMansTSqlFormatterLibShared/Formatters/TSqlStandardFormatter.cs
+++ b/PoorMansTSqlFormatterLibShared/Formatters/TSqlStandardFormatter.cs
@@ -47,7 +47,7 @@ namespace PoorMansTSqlFormatterLib.Formatters
         }
 
         [Obsolete("Use the constructor with the TSqlStandardFormatterOptions parameter")]
-        public TSqlStandardFormatter(string indentString, int spacesPerTab, int maxLineWidth, bool expandCommaLists, bool trailingCommas, bool spaceAfterExpandedComma, bool expandBooleanExpressions, bool expandCaseStatements, bool expandBetweenConditions, bool breakJoinOnSections, bool uppercaseKeywords, bool htmlColoring, bool keywordStandardization)
+        public TSqlStandardFormatter(string indentString, int spacesPerTab, int maxLineWidth, bool expandCommaLists, bool trailingCommas, bool spaceAfterExpandedComma, bool expandBooleanExpressions, bool expandCaseStatements, bool expandSelectStatements, bool expandBetweenConditions, bool breakJoinOnSections, bool uppercaseKeywords, bool htmlColoring, bool keywordStandardization)
         {
             Options = new TSqlStandardFormatterOptions
                 {
@@ -60,6 +60,7 @@ namespace PoorMansTSqlFormatterLib.Formatters
                     ExpandBooleanExpressions = expandBooleanExpressions,
                     ExpandBetweenConditions = expandBetweenConditions,
                     ExpandCaseStatements = expandCaseStatements,
+                    ExpandSelectStatements = expandSelectStatements,
                     UppercaseKeywords = uppercaseKeywords,
                     BreakJoinOnSections = breakJoinOnSections,
                     HTMLColoring = htmlColoring,
@@ -258,7 +259,7 @@ namespace PoorMansTSqlFormatterLib.Formatters
                         state.BreakExpected = true;
                     ProcessSqlNodeList(contentElement.ChildrenByName(SqlStructureConstants.ENAME_CONTAINER_OPEN), state);
                     if (Options.BreakJoinOnSections)
-                        state.IncrementIndent();
+                      state.IncrementIndent();
                     ProcessSqlNodeList(contentElement.ChildrenByName(SqlStructureConstants.ENAME_CONTAINER_GENERALCONTENT), state);
                     if (Options.BreakJoinOnSections)
                         state.DecrementIndent();
@@ -626,7 +627,14 @@ namespace PoorMansTSqlFormatterLib.Formatters
                     WhiteSpace_SeparateWords(state);
                     state.SetRecentKeyword(contentElement.TextValue);
                     state.AddOutputContent(FormatKeyword(contentElement.TextValue), SqlHtmlConstants.CLASS_KEYWORD);
-                    state.WordSeparatorExpected = true;
+                    if (Options.ExpandSelectStatements && contentElement.Parent.ChildrenByName(SqlStructureConstants.ENAME_COMMA).Any())
+                    {
+                        state.BreakExpected = true;
+                    }
+                    else
+                    {
+                        state.WordSeparatorExpected = true;
+                    }
                     break;
 
                 case SqlStructureConstants.ENAME_PSEUDONAME:

--- a/PoorMansTSqlFormatterLibShared/Formatters/TSqlStandardFormatterOptions.cs
+++ b/PoorMansTSqlFormatterLibShared/Formatters/TSqlStandardFormatterOptions.cs
@@ -40,6 +40,7 @@ namespace PoorMansTSqlFormatterLib.Formatters
             ExpandBooleanExpressions = true;
             ExpandBetweenConditions = true;
             ExpandCaseStatements = true;
+            ExpandSelectStatements = false;
             UppercaseKeywords = true;
             BreakJoinOnSections = false;
             HTMLColoring = false;
@@ -75,6 +76,7 @@ namespace PoorMansTSqlFormatterLib.Formatters
 				else if (key == "ExpandBooleanExpressions") ExpandBooleanExpressions = Convert.ToBoolean(value);
 				else if (key == "ExpandBetweenConditions") ExpandBetweenConditions = Convert.ToBoolean(value);
 				else if (key == "ExpandCaseStatements") ExpandCaseStatements = Convert.ToBoolean(value);
+                else if (key == "ExpandSelectStatements") ExpandSelectStatements = Convert.ToBoolean(value);
 				else if (key == "UppercaseKeywords") UppercaseKeywords = Convert.ToBoolean(value);
 				else if (key == "BreakJoinOnSections") BreakJoinOnSections = Convert.ToBoolean(value);
 				else if (key == "HTMLColoring") HTMLColoring = Convert.ToBoolean(value);
@@ -103,6 +105,7 @@ namespace PoorMansTSqlFormatterLib.Formatters
             if (ExpandBooleanExpressions != _defaultOptions.ExpandBooleanExpressions) overrides.Add("ExpandBooleanExpressions", ExpandBooleanExpressions.ToString());
             if (ExpandBetweenConditions != _defaultOptions.ExpandBetweenConditions) overrides.Add("ExpandBetweenConditions", ExpandBetweenConditions.ToString());
             if (ExpandCaseStatements != _defaultOptions.ExpandCaseStatements) overrides.Add("ExpandCaseStatements", ExpandCaseStatements.ToString());
+            if (ExpandSelectStatements != _defaultOptions.ExpandSelectStatements) overrides.Add("ExpandSelectStatements", ExpandSelectStatements.ToString());
             if (UppercaseKeywords != _defaultOptions.UppercaseKeywords) overrides.Add("UppercaseKeywords", UppercaseKeywords.ToString());
             if (BreakJoinOnSections != _defaultOptions.BreakJoinOnSections) overrides.Add("BreakJoinOnSections", BreakJoinOnSections.ToString());
             if (HTMLColoring != _defaultOptions.HTMLColoring) overrides.Add("HTMLColoring", HTMLColoring.ToString());
@@ -137,6 +140,7 @@ namespace PoorMansTSqlFormatterLib.Formatters
         public bool SpaceAfterExpandedComma { get; set; }
         public bool ExpandBooleanExpressions { get; set; }
         public bool ExpandCaseStatements { get; set; }
+        public bool ExpandSelectStatements { get; set; }
         public bool ExpandBetweenConditions { get; set; }
         public bool UppercaseKeywords { get; set; }
         public bool BreakJoinOnSections { get; set; }

--- a/PoorMansTSqlFormatterTest/CmdLineTests.cs
+++ b/PoorMansTSqlFormatterTest/CmdLineTests.cs
@@ -39,6 +39,7 @@ namespace PoorMansTSqlFormatterTests
         {
             TestFormattingFlags("SELECT 1, 2", "SELECT 1\r\n\t,2", "");
             TestFormattingFlags("SELECT 1, 2", "SELECT 1, 2", "/ecl-");
+            TestFormattingFlags("SELECT 1, 2", "SELECT\r\n\t1\r\n\t,2", "/ess");
             TestFormattingFlags("SELECT 1, 2", "SELECT 1\r\n ,2", "/is:\" \"");
             TestFormattingFlags("SELECT 1, 2", "SELECT 1\r\n\t, 2", "/sac");
             TestFormattingFlags("SELECT 1, 2", "SELECT 1,\r\n\t2", "/tc");

--- a/PoorMansTSqlFormatterTest/TSqlStandardFormatterOptionsTests.cs
+++ b/PoorMansTSqlFormatterTest/TSqlStandardFormatterOptionsTests.cs
@@ -47,6 +47,7 @@ namespace PoorMansTSqlFormatterTests
             Assert.IsFalse(options.SpaceAfterExpandedComma);
             Assert.IsTrue(options.ExpandBooleanExpressions);
             Assert.IsTrue(options.ExpandCaseStatements);
+            Assert.IsFalse(options.ExpandSelectStatements);
             Assert.IsTrue(options.ExpandBetweenConditions);
             Assert.IsFalse(options.BreakJoinOnSections);
             Assert.IsTrue(options.UppercaseKeywords);
@@ -74,6 +75,7 @@ namespace PoorMansTSqlFormatterTests
                 + ",SpaceAfterExpandedComma=true"
                 + ",ExpandBooleanExpressions=False"
                 + ",ExpandCaseStatements=false"
+                + ",ExpandSelectStatements=true"
                 + ",ExpandBetweenConditions=false"
                 + ",BreakJoinOnSections=true"
                 + ",UppercaseKeywords=false"
@@ -89,6 +91,7 @@ namespace PoorMansTSqlFormatterTests
             Assert.IsTrue(options.SpaceAfterExpandedComma);
             Assert.IsFalse(options.ExpandBooleanExpressions);
             Assert.IsFalse(options.ExpandCaseStatements);
+            Assert.IsTrue(options.ExpandSelectStatements);
             Assert.IsFalse(options.ExpandBetweenConditions);
             Assert.IsTrue(options.BreakJoinOnSections);
             Assert.IsFalse(options.UppercaseKeywords);
@@ -109,6 +112,7 @@ namespace PoorMansTSqlFormatterTests
                     SpaceAfterExpandedComma = true,
                     ExpandBooleanExpressions = false,
                     ExpandCaseStatements = false,
+                    ExpandSelectStatements = true,
                     ExpandBetweenConditions = false,
                     BreakJoinOnSections = true,
                     UppercaseKeywords = false,
@@ -128,6 +132,7 @@ namespace PoorMansTSqlFormatterTests
             Assert.AreEqual(expected.SpaceAfterExpandedComma, actual.SpaceAfterExpandedComma);
             Assert.AreEqual(expected.ExpandBooleanExpressions, actual.ExpandBooleanExpressions);
             Assert.AreEqual(expected.ExpandCaseStatements, actual.ExpandCaseStatements);
+            Assert.AreEqual(expected.ExpandSelectStatements, actual.ExpandSelectStatements);
             Assert.AreEqual(expected.ExpandBetweenConditions, actual.ExpandBetweenConditions);
             Assert.AreEqual(expected.BreakJoinOnSections, actual.BreakJoinOnSections);
             Assert.AreEqual(expected.UppercaseKeywords, actual.UppercaseKeywords);


### PR DESCRIPTION
Added an option to expand select statements, e.g.:
```sql
select a, b, c from d
```
becomes:
```sql
select
  a, b, c 
from d
```
or, with _Expand Comma Lists_ and _Trailing commas_ enabled:
```sql
select
  a,
  b,
  c
from d
```

Also added the option to and fixed some sizing issues of the demo application.